### PR TITLE
Update return value for multiple atlas branch update

### DIFF
--- a/src/UVUnwrapper.ts
+++ b/src/UVUnwrapper.ts
@@ -89,11 +89,10 @@ export abstract class BaseUVUnwrapper{
         geometries: BufferGeometry[]
     }>{
         if(!this._libraryLoaded) {
-            console.warn('xatlas-three: library not loaded')
-            return [];
+            throw new Error('xatlas-three: library not loaded');
         }
-        if (!nodeList) return [];
-        if(nodeList.length < 1) return [];
+        if (!nodeList) throw new Error('xatlas-three: nodeList argument not provided');
+        if(nodeList.length < 1) throw new Error('xatlas-three: nodeList must have non-zero length');
         const useUvs = this.chartOptions.useInputMeshUvs;
 
         while (this._isUnwrapping){


### PR DESCRIPTION
Updates the return value of `packAtlas` to include both the return atlas data and the processed geometries in the same order as in the atlas object. Sets the "materialIndex" to the atlas index. Throws errors instead of silently failing and returning empty arrays.

Setting the materialIndex to the atlas index feels a bit odd to me and with that set it may not be necessary to return the atlas object but I think it's worth returning in case the user wants to do something else with the processed arrays. With this you can generate a list of meshes in a chart which can subsequently be used for rendering light maps:

```js
// collect the geometries in the scene
const geometries = new Set();
scene.traverse( c => c.geometry && geometries.add( c.geometry ) );

// generate geometry atlases
const result = unwrapper.packAtlas( Array.from( geometries ), ... );

// generate a new render targets for the light maps
const renderTargets = new Array( result.atlas.atlasCount ).fill()
  .map( () => new RenderTarget( result.atlas.width, result.atlas.height, { ... } ) );

// generate the light maps
scene.traverse( c => {

  if ( c.isMesh ) {

    const index = result.geometries.index( c.geometry );
    const data = result.atlas.meshes[ index ];
    data.subMeshes.forEach( ( { start, count, atlasIndex } => {

      renderer.setRenderTarget( renderTargets[ atlasIndex ] );

      // render the triangles from start, count using a compute shader, traditional shader

    } );

  }

} );
```