### PR TITLE
Fix package.json fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "main": "public/build/index.js",
     "module": "public/build/index.js",
     "types": "public/build/index.d.ts",
-    "soruce": "src/index.ts",
+    "type": "module",
+    "source": "src/index.ts",
     "scripts": {
         "start": "webpack serve",
         "build": "webpack --mode=production",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,10 @@
-const path = require('path')
+import path from 'path';
+import url from 'url';
 
-module.exports = (env)=>({
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default (env)=>({
     mode: 'development',
     devtool: 'source-map',
     entry: env.no_worker ? './src/unwrapperJS.ts' : './src/unwrapperWorker.ts',


### PR DESCRIPTION
- "source" was misspelled
- No "type" field causes an error to throw when importing in node.js